### PR TITLE
SEARCH-753 -- map & and @ to ' and ' and ' at '

### DIFF
--- a/source/functions/parse_field_tree.js
+++ b/source/functions/parse_field_tree.js
@@ -8,13 +8,6 @@ Pride.FieldTree.parseField = function(field_name, content) {
     return {};
   } else {
     try {
-      content = content
-        .replace(/[“”]/g, '"')
-        .replace(/ [:&]/g, ' ')
-        .replace(/[:&] /g, ' ')
-        .replace(/[:&]$/g, '')
-        .replace(/^[:&]/g, '')
-        ;
       return Pride.Parser.parse(content, {defaultFieldName: field_name});
     }
     catch (e) {


### PR DESCRIPTION
Indexing has already been changed to do the mapping above. This
PR removes pre-processing of search terms which deleted '&' so
the new indexing strategy can go into effect.