### PR TITLE
DO NOT MERGE -- SEARCH-824 -- expand '@' and '&' in searches

### DIFF
--- a/source/functions/parse_field_tree.js
+++ b/source/functions/parse_field_tree.js
@@ -8,13 +8,13 @@ Pride.FieldTree.parseField = function(field_name, content) {
     return {};
   } else {
     try {
-      content = content
-        .replace(/[“”]/g, '"')
-        .replace(/ [:&]/g, ' ')
-        .replace(/[:&] /g, ' ')
-        .replace(/[:&]$/g, '')
-        .replace(/^[:&]/g, '')
-        ;
+//      content = content
+//        .replace(/[“”]/g, '"')
+//        .replace(/ [:&]/g, ' ')
+//        .replace(/[:&] /g, ' ')
+//        .replace(/[:&]$/g, '')
+//        .replace(/^[:&]/g, '')
+//        ;
       return Pride.Parser.parse(content, {defaultFieldName: field_name});
     }
     catch (e) {


### PR DESCRIPTION
ONLY WORKS IN CATALOG CURRENTLY; BREAKS EVERYTHING ELSE

Stop removing '&' and '@' from search strings

'@' and '&' are now expanded to ' and ' and ' at ',
respectively, at the solr level. No need to ditch
them here.