### PR TITLE
Upgrade dependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,7 @@ gulp.task('scripts', gulp.series('parser2', function() {
            './source/singletons/**/*.js'
          ])
          .pipe(babel({
-           presets: ['es2015']
+           presets: ['env']
          }))
         .pipe(concat('pride.js'))
         .pipe(gulp.dest('./'))

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.1",
   "main": "pride.js",
   "dependencies": {
-    "gulp-clean": "^0.3.2",
-    "gulp-pegjs": "^0.1.0",
+    "gulp-clean": "^0.4.0",
+    "gulp-pegjs": "^0.2.0",
     "pegjs": "^0.10.0",
     "reqwest": "^2.0.5",
     "underscore": "^1.8.3",
-    "xhr2": "^0.1.4"
+    "xhr2": "^0.2.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.18.0",
@@ -17,9 +17,9 @@
     "gulp-babel": "^6.1.2",
     "gulp-concat": "^2.6.1",
     "gulp-jshint": "^2.0.4",
-    "gulp-rename": "^1.2.2",
+    "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
-    "gulp-uglify": "^2.0.0",
+    "gulp-uglify": "^3.0.2",
     "jshint": "^2.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "xhr2": "^0.2.0"
   },
   "devDependencies": {
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-es2016": "^6.16.0",
+    "babel-preset-env": "^1.7.0",
     "gulp": "^4.0",
     "gulp-babel": "^6.1.2",
     "gulp-concat": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "xhr2": "^0.2.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.12.10",
     "babel-preset-env": "^1.7.0",
     "gulp": "^4.0",
-    "gulp-babel": "^6.1.2",
+    "gulp-babel": "^8.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-jshint": "^2.0.4",
     "gulp-rename": "^2.0.0",


### PR DESCRIPTION
# Overview
This pull requests updates dependencies for Pride to fix the warnings that showed up after typing `yarn install`:
```
warning gulp-clean > gulp-util@2.2.20: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning gulp-pegjs > gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read https://babeljs.io/env to update!
warning babel-preset-es2016@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read https://babeljs.io/env to update!
warning gulp-babel > babel-core > babel-register > core-js@2.6.12: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
```
## New Dependencies
### babel-preset-env
This dependency was installed to replace `babel-preset-es2015` and `babel-preset-es2016`. `gulpfile.js` had to be updated to apply the new dependency.

### @babel/core
Upgrading `gulp-babel` to two major versions required the core to be compatible, so `@babel/core` was added.

## Testing
Switch to this branch and type `yarn install`. After installation, be sure you can run `yarn exec gulp`. Also test in the Search repository to see if the changes break the site.