### PR TITLE
Installing JSDOM for unit testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
     "gulp-uglify": "^3.0.2",
+    "jsdom": "^16.4.0",
     "jshint": "^2.9.4",
     "mocha": "^8.2.1"
   }

--- a/src/Pride/Util/deepClone.test.js
+++ b/src/Pride/Util/deepClone.test.js
@@ -1,7 +1,7 @@
-import deepClone from './deepClone';
 import { expect } from 'chai';
+import deepClone from './deepClone';
 
-describe.only('deepClone()', () => {
+describe('deepClone()', () => {
   it('passes functions straight through', () => {
     const func = () => {};
     const cloned = deepClone(func);


### PR DESCRIPTION
This allows unit tests to test for DOM. Without it, `window` and `document` would be seen as `undefined`.

Sample test:

```js
import { JSDOM } from 'jsdom';
import { expect } from 'chai';

describe('Testing JSDOM', () => {
  before(() => {
    const dom = new JSDOM('<!DOCTYPE html><html><head></head><body><p id="msg">Hello, World!</p></body></html>');
    global.window = dom.window;
    global.document = dom.window.document;
  });
  it('Check if #msg says "Hello, World!"', () => {
    expect(document.getElementById('msg').innerHTML).to.equal('Hello, World!');
  });
});

```