### PR TITLE
Pride.Util.Paginater() functions and unit tests

### DIFF
--- a/src/Pride.js
+++ b/src/Pride.js
@@ -1,9 +1,11 @@
 'use strict';
 
 import Util from './Pride/Util.js';
+import Paginater from './Pride/Util/Paginater';
 
 const Pride = {};
 
 Object.defineProperty(Pride, 'Util', { value: Util });
+Object.defineProperty(Pride.Util, 'Paginater', { value: Paginater });
 
 export default Pride;

--- a/src/Pride/Util.js
+++ b/src/Pride/Util.js
@@ -1,6 +1,7 @@
 import deepClone from './Util/deepClone';
 import escape from './Util/escape';
 import isDeepMatch from './Util/isDeepMatch';
+import Paginater from './Util/Paginater';
 import safeApply from './Util/safeApply';
 import safeCall from './Util/safeCall';
 import slice from './Util/slice';
@@ -13,5 +14,7 @@ const Util = {
   safeCall: (maybeFunc) => safeCall(maybeFunc),
   slice: (array, begin, end) => slice(array, begin, end)
 };
+
+Object.defineProperty(Util, 'Paginater', { value: Paginater });
 
 export default Util;

--- a/src/Pride/Util/Paginater.js
+++ b/src/Pride/Util/Paginater.js
@@ -3,7 +3,7 @@ import hasKey from './Paginater/hasKey';
 
 const Paginater = {
   getPossibleKeys: () => getPossibleKeys(),
-  hasKey: (args) => hasKey(args)
+  hasKey: (key) => hasKey(key)
 };
 
 export default Paginater;

--- a/src/Pride/Util/Paginater.js
+++ b/src/Pride/Util/Paginater.js
@@ -1,9 +1,120 @@
+import { _ } from 'underscore';
 import getPossibleKeys from './Paginater/getPossibleKeys';
 import hasKey from './Paginater/hasKey';
 
-const Paginater = {
-  getPossibleKeys: () => getPossibleKeys(),
-  hasKey: (key) => hasKey(key)
+const Paginater = function(initialValues) {
+  this.set = function(newValues) {
+    /*
+     * Basic error checks
+     */
+
+    if (_.has(newValues, 'total_pages')) {
+      throw new Error('Can not set total_pages (it is a calculated value)');
+    }
+
+    if (_.has(newValues, 'index_limit')) {
+      throw new Error('Can not set index_limit (it is a calculated value)');
+    }
+
+    if (_.intersection(['start', 'end', 'count'], _.keys(newValues)).length > 2) {
+      throw new Error('Can not set start, end and count all at the same time');
+    }
+
+    if (
+      _.has(newValues, 'page') &&
+      (_.has(newValues, 'start') || _.has(newValues, 'end'))
+    ) {
+      throw new Error('Can not set page as well as the start and/or end');
+    }
+
+    /*
+     * Set and calculate values
+     */
+
+    // We wait to set the new end value until after an exception can be thrown.
+    _.extend(values, _.omit(newValues, 'end'));
+
+    // If the page is being set, we have to update the start.
+    if (_.has(newValues, 'page')) {
+      values.start = (values.count || 0) * (values.page - 1);
+    }
+
+    // If the end is being set, we calculate what start or count should now be.
+    if (_.has(newValues, 'end')) {
+      // If we are also setting the count, calculate a new start.
+      if (_.has(newValues, 'count')) {
+        values.start = Math.max(0, newValues.end - (values.count - 1));
+      // If we are not setting the count, calculate a new count.
+      } else {
+        /*
+         * Throw an error if the start now comes after the end,
+         * because that makes no sense at all.
+         */
+        if (values.start <= newValues.end) {
+          values.count = (newValues.end - values.start) + 1;
+        } else {
+          throw new Error('The start value can not be greater than the end value');
+        }
+      }
+
+      // Now it is safe to set the end
+      values.end = newValues.end;
+    } else {
+      // Calculate what the new end value should be.
+      const end = values.start + values.count - 1;
+      values.end = (end < values.start) ? undefined : end;
+    }
+
+    // Calculate what the last index can be.
+    if (!_.isNumber(values.total_available)) {
+      values.index_limit = Infinity;
+    } else if (values.total_available > 0) {
+      values.index_limit = values.total_available - 1;
+    } else {
+      values.index_limit = undefined;
+    }
+
+    /*
+     * Calculate pagination
+     */
+
+    if (values.count > 0 && values.start % values.count === 0) {
+      values.page = Math.floor(values.start / values.count) + 1;
+
+      if (_.isNumber(values.total_available)) {
+        values.total_pages = Math.ceil(values.total_available / values.count);
+        values.page_limit = values.total_pages;
+      } else {
+        values.total_pages = undefined;
+        values.page_limit = Infinity;
+      }
+    } else {
+      values.page = undefined;
+      values.total_pages = undefined;
+      values.page_limit = undefined;
+    }
+
+    /*
+     * Check to make sure enough is set
+     */
+
+    if (!_.has(values, 'start') || !_.has(values, 'count')) {
+      throw new Error('Not enough information given to create Paginater');
+    }
+
+    return this;
+  };
+
+  this.get = function(name) {
+    return values[name];
+  };
+
+  // Set the initial values.
+  const values = {};
+  this.set(initialValues);
 };
+
+Paginater.prototype.getPossibleKeys = () => getPossibleKeys();
+Paginater.prototype.hasKey = (key) => hasKey(key);
 
 export default Paginater;

--- a/src/Pride/Util/Paginater.test.js
+++ b/src/Pride/Util/Paginater.test.js
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import { _ } from 'underscore';
+import Paginater from './Paginater';
+
+const paginatorBasicExpectations = (key1, key2, valid) => {
+  beforeEach(function() {
+    const settings = {};
+    settings[key1] = valid[key1];
+    settings[key2] = valid[key2];
+    this.example = new Paginater(settings);
+  });
+
+  _.each(valid, (value, key) => {
+    it(`sets ${key} correctly`, () => {
+      expect(valid[key]).to.equal(value);
+    });
+  });
+
+  it('sets page_limit to Infinity', function() {
+    expect(this.example.get('page_limit')).to.equal(Infinity);
+  });
+
+  it('sets index_limit to Infinity', function() {
+    expect(this.example.get('index_limit')).to.equal(Infinity);
+  });
+
+  it('sets total_pages to undefined', function() {
+    expect(this.example.get('total_pages')).to.equal(undefined);
+  });
+
+  it('sets total_available to undefined', function() {
+    expect(this.example.get('total_available')).to.equal(undefined);
+  });
+};
+
+// Test setting basic values
+const testPaginatorBasics = (key1, key2) => {
+  describe(`given a valid ${key1} and ${key2}`, function() {
+    paginatorBasicExpectations(key1, key2, { start: 10, count: 5, end: 14, page: 3 });
+    paginatorBasicExpectations(key1, key2, { start: 500, count: 100, end: 599, page: 6 });
+  });
+};
+
+const testPaginatorUnsettable = (invalidSettings, basicSettings) => {
+  basicSettings = basicSettings || { start: 10, count: 5 };
+
+  it(
+    `cannot set ${_.keys(invalidSettings).join(' and ')} together after initializaion`,
+    () => {
+      expect(() => (new Paginater(basicSettings)).set(invalidSettings)).to.throw();
+    }
+  );
+
+  it(
+    `cannot set ${_.keys(invalidSettings).join(' and ')} together on initializaion`,
+    () => {
+      expect(() => new Paginater(_.extend(basicSettings, invalidSettings))).to.throw();
+    }
+  );
+};
+
+describe('Paginater', function() {
+  testPaginatorBasics('start', 'count');
+  testPaginatorBasics('start', 'end');
+  testPaginatorBasics('count', 'end');
+
+  describe('certain combinations cannot be set', function() {
+    testPaginatorUnsettable({ total_pages: 100 });
+    testPaginatorUnsettable({ index_limit: 100 });
+    testPaginatorUnsettable({ start: 10, count: 5, end: 14 });
+    testPaginatorUnsettable({ page: 3, start: 10 }, {});
+    testPaginatorUnsettable({ page: 3, end: 14 }, {});
+
+    it('cannot set the start greater than the end', () => {
+      expect(() => new Paginater({ start: 10, end: 5 })).to.throw();
+    });
+  });
+});

--- a/src/Pride/Util/Paginater/getPossibleKeys.js
+++ b/src/Pride/Util/Paginater/getPossibleKeys.js
@@ -9,4 +9,4 @@ export default function getPossibleKeys() {
     'total_available',
     'page_limit'
   ];
-}
+};

--- a/src/Pride/Util/Paginater/getPossibleKeys.test.js
+++ b/src/Pride/Util/Paginater/getPossibleKeys.test.js
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+import getPossibleKeys from './getPossibleKeys';
+
+describe('getPossibleKeys()', () => {
+  it('returns an array', () => {
+    expect(getPossibleKeys()).to.be.an('array');
+  });
+  it('returns all possible keys', () => {
+    expect(getPossibleKeys()).to.deep.equal([...getPossibleKeys()]);
+  });
+});

--- a/src/Pride/Util/Paginater/hasKey.js
+++ b/src/Pride/Util/Paginater/hasKey.js
@@ -1,5 +1,5 @@
 import getPossibleKeys from './getPossibleKeys';
 
 export default function hasKey(key) {
-  return getPossibleKeys().indexOf(key) > -1;
-}
+  return getPossibleKeys().includes(key);
+};

--- a/src/Pride/Util/Paginater/hasKey.test.js
+++ b/src/Pride/Util/Paginater/hasKey.test.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import getPossibleKeys from './getPossibleKeys';
+import hasKey from './hasKey';
+
+describe('hasKey()', () => {
+  it('returns true when asked for any key that exists', () => {
+    const allKeys = [...getPossibleKeys()];
+    const hasAllKeys = allKeys.every((key) => hasKey(key));
+    expect(hasAllKeys).to.be.true;
+  });
+
+  it('returns false when asked for a key that does not exist', () => {
+    expect(hasKey('bloop')).to.be.false;
+  });
+});


### PR DESCRIPTION
# Overview
This pull request will be adding `Pride.Util.Paginater()`, `Pride.Util.Paginater.getPossibleKeys()`, and `Pride.Util.Paginater.hasKey()` to the rewrite, along with their associated unit tests.

## Setup
I am not entirely sure if `Paginater` should be set up as a class or a function. I am also not sure if the setups in `Pride.js`, `Util.js`, and `Paginater.js` are appropriate. Please let me know if there's a better way to handle these. Getting this right will help guide me for future rewrites.

## Testing
* Run `npm run tests` to make sure the tests pass. Try and break the tests to double-check.
* Compare `./src/Pride/Util/Paginater.js`, `./src/Pride/Util/Paginater/getPossibleKeys.js`, and `./src/Pride/Util/Paginater/hasKey.js` against `./source/constructors/paginater.js`.
* Compare `./src/Pride/Util/Paginater.test.js`, `./src/Pride/Util/Paginater/getPossibleKeys.test.js`, and `./src/Pride/Util/Paginater/hasKey.test.js` against `./spec/constructors/paginater_spec.js`.