### PR TITLE
[SEARCH-1306] Pride.Core.log()

### DIFF
--- a/src/Pride/Core.js
+++ b/src/Pride/Core.js
@@ -1,6 +1,8 @@
+import log from './Core/log';
 import nodeFactory from './Core/nodeFactory';
 
 const Core = {
+  log: (source, info) => log(source, info),
   nodeFactory: (type, childTypes, extention) => nodeFactory(type, childTypes, extention)
 };
 

--- a/src/Pride/Core/log.js
+++ b/src/Pride/Core/log.js
@@ -1,11 +1,11 @@
-// import Settings from '../Settings';
-// import slice from '../Util/slice';
+import Settings from '../Settings';
+import slice from '../Util/slice';
 
 export default function log(source, info) {
-  // if (Pride.Settings.obnoxious) {
-  //   var message = Pride.Util.slice(arguments, 2);
-  //   message.unshift('[Pride: ' + source + '] ' + info);
+  if (Settings.obnoxious) {
+    const message = slice(arguments, 2);
+    message.unshift(`[Pride: ${source}] ${info}`);
 
-  //   console.log.apply(console, message);
-  // }
+    console.log.apply(console, message);
+  }
 }

--- a/src/Pride/Core/log.js
+++ b/src/Pride/Core/log.js
@@ -1,0 +1,11 @@
+// import Settings from '../Settings';
+// import slice from '../Util/slice';
+
+export default function log(source, info) {
+  // if (Pride.Settings.obnoxious) {
+  //   var message = Pride.Util.slice(arguments, 2);
+  //   message.unshift('[Pride: ' + source + '] ' + info);
+
+  //   console.log.apply(console, message);
+  // }
+}

--- a/src/Pride/Core/log.test.js
+++ b/src/Pride/Core/log.test.js
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+import log from './log';
+
+describe.only('log()', () => {
+  it('does a thing', () => {
+    console.log(log);
+    expect(log).to.not.be.null;
+  });
+});

--- a/src/Pride/Core/log.test.js
+++ b/src/Pride/Core/log.test.js
@@ -1,9 +1,31 @@
 import { expect } from 'chai';
-import log from './log';
+import Settings from '../Settings';
+import slice from '../Util/slice';
 
-describe.only('log()', () => {
-  it('does a thing', () => {
-    console.log(log);
-    expect(log).to.not.be.null;
+function logCopy(source, info) {
+  if (Settings.obnoxious) {
+    const message = slice(arguments, 2);
+    message.unshift(`[Pride: ${source}] ${info}`);
+
+    return message[0];
+  }
+}
+
+describe('log()', () => {
+  describe('if Settings.obnoxious is false', () => {
+    beforeEach(() => {
+      Settings.obnoxious = false;
+    });
+    it('returns undefined', () => {
+      expect(logCopy('Request', 'Trying request again...')).to.be.undefined;
+    });
+  });
+  describe('if Settings.obnoxious is true', () => {
+    beforeEach(() => {
+      Settings.obnoxious = true;
+    });
+    it('returns a message', () => {
+      expect(logCopy('Request', 'Trying request again...')).to.equal('[Pride: Request] Trying request again...');
+    });
   });
 });


### PR DESCRIPTION
# Overview
This pull request will be adding `Pride.Core.log()` to the rewrite, along with its associated unit test.

## Unit Test
Since the original function applies `console.log`, a copy of the function has been added directly to the unit test to just return the `message`.

## Testing
* Run `npm run tests` to make sure the tests pass. Try and break the tests to double-check.
* Compare `./src/Pride/Core/log.js` against `./source/functions/log.js`.