### PR TITLE
Initialize Pride.Core

### DIFF
--- a/src/Pride.js
+++ b/src/Pride.js
@@ -1,11 +1,15 @@
 'use strict';
 
+import Core from './Pride/Core';
+
 import Settings from './Pride/Settings.js';
 
 import Util from './Pride/Util.js';
 import Paginater from './Pride/Util/Paginater';
 
 const Pride = {};
+
+Object.defineProperty(Pride, 'Core', { value: Core });
 
 Object.defineProperty(Pride, 'Settings', { value: Settings });
 


### PR DESCRIPTION
`Pride.Core.log()` did not work. Had to define `Core` as a property to `Pride`.