### PR TITLE
[SEARCH-1307] Pride.Util.FuncBuffer()

### DIFF
--- a/src/Pride/Util.js
+++ b/src/Pride/Util.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import deepClone from './Util/deepClone';
 import escape from './Util/escape';
 import FuncBuffer from './Util/FuncBuffer';

--- a/src/Pride/Util.js
+++ b/src/Pride/Util.js
@@ -1,5 +1,6 @@
 import deepClone from './Util/deepClone';
 import escape from './Util/escape';
+import FuncBuffer from './Util/FuncBuffer';
 import isDeepMatch from './Util/isDeepMatch';
 import Paginater from './Util/Paginater';
 import safeApply from './Util/safeApply';
@@ -15,6 +16,7 @@ const Util = {
   slice: (array, begin, end) => slice(array, begin, end)
 };
 
+Object.defineProperty(Util, 'FuncBuffer', { value: FuncBuffer });
 Object.defineProperty(Util, 'Paginater', { value: Paginater });
 
 export default Util;

--- a/src/Pride/Util/FuncBuffer.js
+++ b/src/Pride/Util/FuncBuffer.js
@@ -1,0 +1,61 @@
+import { _ } from 'underscore';
+import slice from './slice';
+import safeApply from './safeApply';
+
+const FuncBuffer = function(extension) {
+  let buffer = {};
+  const self = this;
+
+  const safeGet = function(name) {
+    if (!_.has(buffer, name)) buffer[name] = [];
+
+    return buffer[name];
+  };
+
+  this.add = function(func, name) {
+    safeGet(name).push(func);
+
+    return self;
+  };
+
+  this.remove = function(func, name) {
+    buffer[name] = _.reject(
+      safeGet(name),
+      function(otherFunc) {
+        return func === otherFunc;
+      }
+    );
+
+    return self;
+  };
+
+  this.clear = function(name) {
+    delete buffer[name];
+
+    return self;
+  };
+
+  this.clearAll = function() {
+    buffer = {};
+
+    return self;
+  };
+
+  this.call = function(name) {
+    self.apply(name, slice(arguments, 1));
+
+    return self;
+  };
+
+  this.apply = function(name, args) {
+    _.each(safeGet(name), function(func) {
+      safeApply(func, args);
+    });
+
+    return self;
+  };
+
+  if (_.isFunction(extension)) extension.call(this);
+};
+
+export default FuncBuffer;

--- a/src/Pride/Util/FuncBuffer.js
+++ b/src/Pride/Util/FuncBuffer.js
@@ -4,55 +4,46 @@ import safeApply from './safeApply';
 
 const FuncBuffer = function(extension) {
   let buffer = {};
-  const self = this;
 
-  const safeGet = function(name) {
+  this.safeGet = (name) => {
     if (!_.has(buffer, name)) buffer[name] = [];
-
     return buffer[name];
   };
 
-  this.add = function(func, name) {
-    safeGet(name).push(func);
-
-    return self;
+  this.add = (func, name) => {
+    this.safeGet(name).push(func);
+    return this;
   };
 
-  this.remove = function(func, name) {
+  this.remove = (func, name) => {
     buffer[name] = _.reject(
-      safeGet(name),
-      function(otherFunc) {
-        return func === otherFunc;
-      }
+      this.safeGet(name),
+      (otherFunc) => func === otherFunc
     );
-
-    return self;
+    return this;
   };
 
-  this.clear = function(name) {
+  this.clear = (name) => {
     delete buffer[name];
-
-    return self;
+    return this;
   };
 
-  this.clearAll = function() {
+  this.clearAll = () => {
     buffer = {};
-
-    return self;
+    return this;
   };
 
-  this.call = function(name) {
-    self.apply(name, slice(arguments, 1));
-
-    return self;
+  this.apply = (name, args) => {
+    _.each(
+      this.safeGet(name),
+      (func) => safeApply(func, args)
+    );
+    return this;
   };
 
-  this.apply = function(name, args) {
-    _.each(safeGet(name), function(func) {
-      safeApply(func, args);
-    });
-
-    return self;
+  this.call = (name) => {
+    this.apply(name, slice(arguments, 1));
+    return this;
   };
 
   if (_.isFunction(extension)) extension.call(this);

--- a/src/Pride/Util/FuncBuffer.test.js
+++ b/src/Pride/Util/FuncBuffer.test.js
@@ -1,0 +1,247 @@
+import { expect } from 'chai';
+import FuncBuffer from './FuncBuffer';
+
+/*
+ * function testFuncBufferMethods(name) {
+ *   describe('add()', function() {
+ *     it('returns self', function() {
+ *       const buffer = new FuncBuffer();
+ *       expect(buffer.add(function() {})).toBe(buffer);
+ *     });
+ *   });
+ */
+
+/*
+ *   beforeEach(function() {
+ *     const self = this;
+ *     this.name = name;
+ *     this.another_name = 'another_buffer';
+ *     this.buffer = new FuncBuffer();
+ *     this.number = 0;
+ *     this.another_number = 0;
+ *     this.from_another_name = 0;
+ */
+
+/*
+ *     this.example_function = function() {
+ *       self.number++;
+ *     };
+ */
+
+/*
+ *     this.buffer.add(this.example_function, name)
+ *       .add(function() {
+ *         self.another_number++;
+ *       }, name)
+ *       .add(function() {
+ *         self.from_another_name++;
+ *       }, this.another_name);
+ *   });
+ */
+
+/*
+ *   describe('call()', function() {
+ *     beforeEach(function() {
+ *       this.buffer.call(this.name);
+ *     });
+ */
+
+/*
+ *     it('calls functions registered under the given name', function() {
+ *       expect(this.number).toEqual(1);
+ *       expect(this.another_number).toEqual(1);
+ *     });
+ */
+
+/*
+ *     it("doesn't call functions registered under any other name", function() {
+ *       expect(this.from_another_name).toEqual(0);
+ *     });
+ */
+
+/*
+ *     describe('after a second call()', function() {
+ *       beforeEach(function() {
+ *         this.buffer.call(this.name);
+ *       });
+ */
+
+/*
+ *       it('can be called multiple times', function() {
+ *         expect(this.number).toEqual(2);
+ *         expect(this.another_number).toEqual(2);
+ *       });
+ */
+
+/*
+ *       it('returns the FuncBuffer', function() {
+ *         expect(this.buffer.call(this.name)).toBe(this.buffer);
+ *       });
+ */
+
+/*
+ *       it("with an undefined name doesn't explode", function() {
+ *         expect(this.buffer.call('not_a_defined_name')).toBe(this.buffer);
+ *       });
+ *     });
+ *   });
+ */
+
+/*
+ *   describe('apply()', function() {
+ *     beforeEach(function() {
+ *       const self = this;
+ *       this.touched_1 = false;
+ *       this.touched_2 = false;
+ */
+
+/*
+ *       this.buffer.add(
+ *         function(x, y) {
+ *           if (x && y) self.touched_1 = true;
+ *         },
+ *         this.name
+ *       );
+ */
+
+/*
+ *       this.buffer.add(
+ *         function(x, y) {
+ *           if (x && y) self.touched_2 = true;
+ *         },
+ *         this.name
+ *       );
+ */
+
+/*
+ *       this.buffer.apply(name, [true, true]);
+ *     });
+ */
+
+/*
+ *     it('lets you pass in an argument array', function() {
+ *       expect(this.touched_1).toBe(true);
+ *       expect(this.touched_2).toBe(true);
+ *     });
+ */
+
+/*
+ *     it('returns the FuncBuffer', function() {
+ *       expect(this.buffer.apply(name)).toBe(this.buffer);
+ *     });
+ *   });
+ */
+
+/*
+ *   describe('clear()', function() {
+ *     beforeEach(function() {
+ *       this.buffer.clear(this.name);
+ *       this.buffer.call(this.name);
+ *     });
+ */
+
+/*
+ *     it('removes functions from the named buffer', function() {
+ *       expect(this.number).toEqual(0);
+ *       expect(this.another_number).toEqual(0);
+ *     });
+ */
+
+/*
+ *     describe('on other buffers', function() {
+ *       beforeEach(function() {
+ *         this.buffer.call(this.another_name);
+ *       });
+ */
+
+/*
+ *       it("doesn't clear other buffers", function() {
+ *         expect(this.from_another_name).toEqual(1);
+ *       });
+ *     });
+ */
+
+/*
+ *     it('returns the FuncBuffer', function() {
+ *       expect(this.buffer.clear(this.name)).toEqual(this.buffer);
+ *     });
+ *   });
+ */
+
+/*
+ *   describe('clearAll()', function() {
+ *     beforeEach(function() {
+ *       this.buffer.clearAll(this.name);
+ *       this.buffer.call(this.name);
+ *       this.buffer.call(this.another_name);
+ *     });
+ */
+
+/*
+ *     it('removes functions from all buffers', function() {
+ *       expect(this.number).toEqual(0);
+ *       expect(this.another_number).toEqual(0);
+ *       expect(this.from_another_name).toEqual(0);
+ *     });
+ */
+
+/*
+ *     it('returns the FuncBuffer', function() {
+ *       expect(this.buffer.clear(this.name)).toBe(this.buffer);
+ *     });
+ *   });
+ */
+
+/*
+ *   describe('remove()', function() {
+ *     beforeEach(function() {
+ *       this.buffer.remove(this.example_function, this.name);
+ *       this.buffer.call(this.name);
+ *     });
+ */
+
+/*
+ *     it('only removes the given function', function() {
+ *       expect(this.number).toEqual(0);
+ *       expect(this.another_number).toEqual(1);
+ *     });
+ */
+
+/*
+ *     it('returns the FuncBuffer', function() {
+ *       expect(this.buffer.remove(this.name)).toBe(this.buffer);
+ *     });
+ *   });
+ * }
+ */
+
+describe.only('FuncBuffer', function() {
+  it('does a thing', () => {
+    console.log(FuncBuffer);
+    expect(FuncBuffer).to.not.be.null;
+  });
+  /*
+   * it('can be extended', function() {
+   *   let thisValue = null;
+   *   const example = new FuncBuffer(function() {
+   *     thisValue = this;
+   *   });
+   */
+
+  /*
+   *   expect(example).toEqual(thisValue);
+   * });
+   */
+
+  /*
+   * describe('without a name', function() {
+   *   testFuncBufferMethods();
+   * });
+   */
+
+  /*
+   * describe('with a name', function() {
+   *   testFuncBufferMethods('this_is_a_name');
+   * });
+   */
+});

--- a/src/Pride/Util/FuncBuffer.test.js
+++ b/src/Pride/Util/FuncBuffer.test.js
@@ -5,30 +5,22 @@ function testFuncBufferMethods(name) {
   describe('add()', function() {
     it('returns self', function() {
       const buffer = new FuncBuffer();
-      expect(buffer.add(function() {})).to.equal(buffer);
+      expect(buffer.add(() => {})).to.equal(buffer);
     });
   });
 
   beforeEach(function() {
-    const self = this;
-    this.name = name;
-    this.another_name = 'another_buffer';
     this.buffer = new FuncBuffer();
     this.number = 0;
     this.another_number = 0;
+    this.example_function = () => this.number++;
+    this.name = name;
+    this.another_name = 'another_buffer';
     this.from_another_name = 0;
 
-    this.example_function = function() {
-      self.number++;
-    };
-
     this.buffer.add(this.example_function, name)
-      .add(function() {
-        self.another_number++;
-      }, name)
-      .add(function() {
-        self.from_another_name++;
-      }, this.another_name);
+      .add(() => this.another_number++, name)
+      .add(() => this.from_another_name++, this.another_name);
   });
 
   describe('call()', function() {
@@ -67,20 +59,11 @@ function testFuncBufferMethods(name) {
 
   describe('apply()', function() {
     beforeEach(function() {
-      const self = this;
-      this.touched_1 = false;
-      this.touched_2 = false;
+      this.touched_1 = this.touched_2 = false;
 
       this.buffer.add(
-        function(x, y) {
-          if (x && y) self.touched_1 = true;
-        },
-        this.name
-      );
-
-      this.buffer.add(
-        function(x, y) {
-          if (x && y) self.touched_2 = true;
+        (x, y) => {
+          if (x && y) this.touched_1 = this.touched_2 = true;
         },
         this.name
       );

--- a/src/Pride/Util/FuncBuffer.test.js
+++ b/src/Pride/Util/FuncBuffer.test.js
@@ -1,247 +1,179 @@
 import { expect } from 'chai';
 import FuncBuffer from './FuncBuffer';
 
-/*
- * function testFuncBufferMethods(name) {
- *   describe('add()', function() {
- *     it('returns self', function() {
- *       const buffer = new FuncBuffer();
- *       expect(buffer.add(function() {})).toBe(buffer);
- *     });
- *   });
- */
-
-/*
- *   beforeEach(function() {
- *     const self = this;
- *     this.name = name;
- *     this.another_name = 'another_buffer';
- *     this.buffer = new FuncBuffer();
- *     this.number = 0;
- *     this.another_number = 0;
- *     this.from_another_name = 0;
- */
-
-/*
- *     this.example_function = function() {
- *       self.number++;
- *     };
- */
-
-/*
- *     this.buffer.add(this.example_function, name)
- *       .add(function() {
- *         self.another_number++;
- *       }, name)
- *       .add(function() {
- *         self.from_another_name++;
- *       }, this.another_name);
- *   });
- */
-
-/*
- *   describe('call()', function() {
- *     beforeEach(function() {
- *       this.buffer.call(this.name);
- *     });
- */
-
-/*
- *     it('calls functions registered under the given name', function() {
- *       expect(this.number).toEqual(1);
- *       expect(this.another_number).toEqual(1);
- *     });
- */
-
-/*
- *     it("doesn't call functions registered under any other name", function() {
- *       expect(this.from_another_name).toEqual(0);
- *     });
- */
-
-/*
- *     describe('after a second call()', function() {
- *       beforeEach(function() {
- *         this.buffer.call(this.name);
- *       });
- */
-
-/*
- *       it('can be called multiple times', function() {
- *         expect(this.number).toEqual(2);
- *         expect(this.another_number).toEqual(2);
- *       });
- */
-
-/*
- *       it('returns the FuncBuffer', function() {
- *         expect(this.buffer.call(this.name)).toBe(this.buffer);
- *       });
- */
-
-/*
- *       it("with an undefined name doesn't explode", function() {
- *         expect(this.buffer.call('not_a_defined_name')).toBe(this.buffer);
- *       });
- *     });
- *   });
- */
-
-/*
- *   describe('apply()', function() {
- *     beforeEach(function() {
- *       const self = this;
- *       this.touched_1 = false;
- *       this.touched_2 = false;
- */
-
-/*
- *       this.buffer.add(
- *         function(x, y) {
- *           if (x && y) self.touched_1 = true;
- *         },
- *         this.name
- *       );
- */
-
-/*
- *       this.buffer.add(
- *         function(x, y) {
- *           if (x && y) self.touched_2 = true;
- *         },
- *         this.name
- *       );
- */
-
-/*
- *       this.buffer.apply(name, [true, true]);
- *     });
- */
-
-/*
- *     it('lets you pass in an argument array', function() {
- *       expect(this.touched_1).toBe(true);
- *       expect(this.touched_2).toBe(true);
- *     });
- */
-
-/*
- *     it('returns the FuncBuffer', function() {
- *       expect(this.buffer.apply(name)).toBe(this.buffer);
- *     });
- *   });
- */
-
-/*
- *   describe('clear()', function() {
- *     beforeEach(function() {
- *       this.buffer.clear(this.name);
- *       this.buffer.call(this.name);
- *     });
- */
-
-/*
- *     it('removes functions from the named buffer', function() {
- *       expect(this.number).toEqual(0);
- *       expect(this.another_number).toEqual(0);
- *     });
- */
-
-/*
- *     describe('on other buffers', function() {
- *       beforeEach(function() {
- *         this.buffer.call(this.another_name);
- *       });
- */
-
-/*
- *       it("doesn't clear other buffers", function() {
- *         expect(this.from_another_name).toEqual(1);
- *       });
- *     });
- */
-
-/*
- *     it('returns the FuncBuffer', function() {
- *       expect(this.buffer.clear(this.name)).toEqual(this.buffer);
- *     });
- *   });
- */
-
-/*
- *   describe('clearAll()', function() {
- *     beforeEach(function() {
- *       this.buffer.clearAll(this.name);
- *       this.buffer.call(this.name);
- *       this.buffer.call(this.another_name);
- *     });
- */
-
-/*
- *     it('removes functions from all buffers', function() {
- *       expect(this.number).toEqual(0);
- *       expect(this.another_number).toEqual(0);
- *       expect(this.from_another_name).toEqual(0);
- *     });
- */
-
-/*
- *     it('returns the FuncBuffer', function() {
- *       expect(this.buffer.clear(this.name)).toBe(this.buffer);
- *     });
- *   });
- */
-
-/*
- *   describe('remove()', function() {
- *     beforeEach(function() {
- *       this.buffer.remove(this.example_function, this.name);
- *       this.buffer.call(this.name);
- *     });
- */
-
-/*
- *     it('only removes the given function', function() {
- *       expect(this.number).toEqual(0);
- *       expect(this.another_number).toEqual(1);
- *     });
- */
-
-/*
- *     it('returns the FuncBuffer', function() {
- *       expect(this.buffer.remove(this.name)).toBe(this.buffer);
- *     });
- *   });
- * }
- */
-
-describe.only('FuncBuffer', function() {
-  it('does a thing', () => {
-    console.log(FuncBuffer);
-    expect(FuncBuffer).to.not.be.null;
+function testFuncBufferMethods(name) {
+  describe('add()', function() {
+    it('returns self', function() {
+      const buffer = new FuncBuffer();
+      expect(buffer.add(function() {})).to.equal(buffer);
+    });
   });
-  /*
-   * it('can be extended', function() {
-   *   let thisValue = null;
-   *   const example = new FuncBuffer(function() {
-   *     thisValue = this;
-   *   });
-   */
 
-  /*
-   *   expect(example).toEqual(thisValue);
-   * });
-   */
+  beforeEach(function() {
+    const self = this;
+    this.name = name;
+    this.another_name = 'another_buffer';
+    this.buffer = new FuncBuffer();
+    this.number = 0;
+    this.another_number = 0;
+    this.from_another_name = 0;
 
-  /*
-   * describe('without a name', function() {
-   *   testFuncBufferMethods();
-   * });
-   */
+    this.example_function = function() {
+      self.number++;
+    };
 
-  /*
-   * describe('with a name', function() {
-   *   testFuncBufferMethods('this_is_a_name');
-   * });
-   */
+    this.buffer.add(this.example_function, name)
+      .add(function() {
+        self.another_number++;
+      }, name)
+      .add(function() {
+        self.from_another_name++;
+      }, this.another_name);
+  });
+
+  describe('call()', function() {
+    beforeEach(function() {
+      this.buffer.call(this.name);
+    });
+
+    it('calls functions registered under the given name', function() {
+      expect(this.number).to.equal(1);
+      expect(this.another_number).to.equal(1);
+    });
+
+    it("doesn't call functions registered under any other name", function() {
+      expect(this.from_another_name).to.equal(0);
+    });
+
+    describe('after a second call()', function() {
+      beforeEach(function() {
+        this.buffer.call(this.name);
+      });
+
+      it('can be called multiple times', function() {
+        expect(this.number).to.equal(2);
+        expect(this.another_number).to.equal(2);
+      });
+
+      it('returns the FuncBuffer', function() {
+        expect(this.buffer.call(this.name)).to.equal(this.buffer);
+      });
+
+      it("with an undefined name doesn't explode", function() {
+        expect(this.buffer.call('not_a_defined_name')).to.equal(this.buffer);
+      });
+    });
+  });
+
+  describe('apply()', function() {
+    beforeEach(function() {
+      const self = this;
+      this.touched_1 = false;
+      this.touched_2 = false;
+
+      this.buffer.add(
+        function(x, y) {
+          if (x && y) self.touched_1 = true;
+        },
+        this.name
+      );
+
+      this.buffer.add(
+        function(x, y) {
+          if (x && y) self.touched_2 = true;
+        },
+        this.name
+      );
+
+      this.buffer.apply(name, [true, true]);
+    });
+
+    it('lets you pass in an argument array', function() {
+      expect(this.touched_1).to.be.true;
+      expect(this.touched_2).to.be.true;
+    });
+
+    it('returns the FuncBuffer', function() {
+      expect(this.buffer.apply(name)).to.equal(this.buffer);
+    });
+  });
+
+  describe('clear()', function() {
+    beforeEach(function() {
+      this.buffer.clear(this.name);
+      this.buffer.call(this.name);
+    });
+
+    it('removes functions from the named buffer', function() {
+      expect(this.number).to.equal(0);
+      expect(this.another_number).to.equal(0);
+    });
+
+    describe('on other buffers', function() {
+      beforeEach(function() {
+        this.buffer.call(this.another_name);
+      });
+
+      it("doesn't clear other buffers", function() {
+        expect(this.from_another_name).to.equal(1);
+      });
+    });
+
+    it('returns the FuncBuffer', function() {
+      expect(this.buffer.clear(this.name)).to.equal(this.buffer);
+    });
+  });
+
+  describe('clearAll()', function() {
+    beforeEach(function() {
+      this.buffer.clearAll(this.name);
+      this.buffer.call(this.name);
+      this.buffer.call(this.another_name);
+    });
+
+    it('removes functions from all buffers', function() {
+      expect(this.number).to.equal(0);
+      expect(this.another_number).to.equal(0);
+      expect(this.from_another_name).to.equal(0);
+    });
+
+    it('returns the FuncBuffer', function() {
+      expect(this.buffer.clear(this.name)).to.equal(this.buffer);
+    });
+  });
+
+  describe('remove()', function() {
+    beforeEach(function() {
+      this.buffer.remove(this.example_function, this.name);
+      this.buffer.call(this.name);
+    });
+
+    it('only removes the given function', function() {
+      expect(this.number).to.equal(0);
+      expect(this.another_number).to.equal(1);
+    });
+
+    it('returns the FuncBuffer', function() {
+      expect(this.buffer.remove(this.name)).to.equal(this.buffer);
+    });
+  });
+}
+
+describe('FuncBuffer', function() {
+  it('can be extended', function() {
+    let thisValue = null;
+    const example = new FuncBuffer(function() {
+      thisValue = this;
+    });
+
+    expect(example).to.equal(thisValue);
+  });
+
+  describe('without a name', function() {
+    testFuncBufferMethods();
+  });
+
+  describe('with a name', function() {
+    testFuncBufferMethods('this_is_a_name');
+  });
 });


### PR DESCRIPTION
# Overview
This pull request takes care of [SEARCH-1307](https://tools.lib.umich.edu/jira/browse/SEARCH-1307). It adds `Pride.Util.FuncBuffer` to the rewrite, along with its associated unit test.

## Testing
* Run `npm run tests` to make sure the tests pass. Try and break the tests to double-check.
* Compare `./src/Pride/Util/FuncBuffer` against `./source/constructors/func_buffer.js`.
* Compare `./src/Pride/Util/FuncBuffer.test.js` against `./spec/constructors/func_buffer_spec.js`.