### PR TITLE
[SEACH-1308] Pride.Messenger()

### DIFF
--- a/src/Pride.js
+++ b/src/Pride.js
@@ -1,9 +1,13 @@
 'use strict';
 
+import Messenger from './Pride/Messenger.js';
+
 import Util from './Pride/Util.js';
 import Paginater from './Pride/Util/Paginater';
 
 const Pride = {};
+
+Object.defineProperty(Pride, 'Messenger', { value: Messenger });
 
 Object.defineProperty(Pride, 'Util', { value: Util });
 Object.defineProperty(Pride.Util, 'Paginater', { value: Paginater });

--- a/src/Pride/Messenger.js
+++ b/src/Pride/Messenger.js
@@ -1,8 +1,10 @@
 import { _ } from 'underscore';
 import FuncBuffer from './Util/FuncBuffer';
 import log from './Core/log';
-import Settings from './Settings';
-import slice from './Util/slice';
+/*
+ * import Settings from './Settings';
+ * import slice from './Util/slice';
+ */
 
 const Messenger = new FuncBuffer(function() {
   const notifyObservers = this.call;
@@ -40,15 +42,15 @@ const Messenger = new FuncBuffer(function() {
    */
   this.preset = (type) => {
     /*
-     *const variables = slice(arguments);
+     * const variables = slice(arguments);
      *
-     *return Settings
-     *  .message_formats[type]
-     *  .replace(
-     *    /(^|[^\\])\$(\d+)/,
-     *    (match, previousChar, number) => previousChar + (variables[Number(number)] || '')
-     *  )
-     *  .replace('\\$', '$');
+     * return Settings
+     *   .message_formats[type]
+     *   .replace(
+     *     /(^|[^\\])\$(\d+)/,
+     *     (match, previousChar, number) => previousChar + (variables[Number(number)] || '')
+     *   )
+     *   .replace('\\$', '$');
      */
   };
 });

--- a/src/Pride/Messenger.js
+++ b/src/Pride/Messenger.js
@@ -1,0 +1,71 @@
+/*
+ * import FuncBuffer from './Util/FuncBuffer';
+ * import log from './Core/log';
+ * import Settings from './Settings';
+ * import slice from './Util/slice';
+ */
+
+const Messenger = function() { // const Messenger = new FuncBuffer(function() {
+  const notifyObservers = this.call;
+
+  this.addObserver = this.add;
+  this.removeObserver = this.remove;
+  this.clearObservers = this.clear;
+
+  this.call = undefined;
+  this.add = undefined;
+  this.remove = undefined;
+  this.clear = undefined;
+
+  this.sendMessage = function(message) {
+    /*
+     * if (message['summary']) {
+     *   message['class']   = message['class']   || 'info';
+     *   message['details'] = message['details'] || '';
+     */
+
+    //   notifyObservers(message);
+
+    /*
+     *   Pride.Core.log('Messenger', 'MESSAGE SENT', message);
+     * }
+     */
+
+    // return this;
+  };
+
+  this.sendMessageArray = function(messageArray) {
+    // var messenger = this;
+
+    /*
+     * _.each(
+     *   messageArray,
+     *   function(message) { messenger.sendMessage(message); }
+     * );
+     */
+
+    // return this;
+  };
+
+  /*
+   * Given a type of preset message and some optional arguments, generate a
+   * message string.
+   */
+  this.preset = function(type) {
+    // var variables = Pride.Util.slice(arguments);
+
+    /*
+     * return Pride.Settings
+     *             .message_formats[type]
+     *             .replace(
+     *               /(^|[^\\])\$(\d+)/,
+     *               function(match, previousChar, number) {
+     *                 return previousChar + (variables[Number(number)] || '');
+     *               }
+     *             )
+     *             .replace('\\$', '$');
+     */
+  };
+}; // });
+
+export default Messenger;

--- a/src/Pride/Messenger.js
+++ b/src/Pride/Messenger.js
@@ -1,71 +1,56 @@
-/*
- * import FuncBuffer from './Util/FuncBuffer';
- * import log from './Core/log';
- * import Settings from './Settings';
- * import slice from './Util/slice';
- */
+import { _ } from 'underscore';
+import FuncBuffer from './Util/FuncBuffer';
+import log from './Core/log';
+import Settings from './Settings';
+import slice from './Util/slice';
 
-const Messenger = function() { // const Messenger = new FuncBuffer(function() {
+const Messenger = new FuncBuffer(function() {
   const notifyObservers = this.call;
-
-  this.addObserver = this.add;
-  this.removeObserver = this.remove;
-  this.clearObservers = this.clear;
 
   this.call = undefined;
   this.add = undefined;
   this.remove = undefined;
   this.clear = undefined;
 
-  this.sendMessage = function(message) {
-    /*
-     * if (message['summary']) {
-     *   message['class']   = message['class']   || 'info';
-     *   message['details'] = message['details'] || '';
-     */
+  this.sendMessage = (message) => {
+    if (message.summary) {
+      message.class = message.class || 'info';
+      message.details = message.details || '';
 
-    //   notifyObservers(message);
+      notifyObservers(message.class, message);
 
-    /*
-     *   Pride.Core.log('Messenger', 'MESSAGE SENT', message);
-     * }
-     */
+      log('Messenger', 'MESSAGE SENT', message);
+    }
 
-    // return this;
+    return this;
   };
 
-  this.sendMessageArray = function(messageArray) {
-    // var messenger = this;
+  this.sendMessageArray = (messageArray) => {
+    _.each(
+      messageArray,
+      (message) => this.sendMessage(message)
+    );
 
-    /*
-     * _.each(
-     *   messageArray,
-     *   function(message) { messenger.sendMessage(message); }
-     * );
-     */
-
-    // return this;
+    return this;
   };
 
   /*
    * Given a type of preset message and some optional arguments, generate a
    * message string.
    */
-  this.preset = function(type) {
-    // var variables = Pride.Util.slice(arguments);
-
+  this.preset = (type) => {
     /*
-     * return Pride.Settings
-     *             .message_formats[type]
-     *             .replace(
-     *               /(^|[^\\])\$(\d+)/,
-     *               function(match, previousChar, number) {
-     *                 return previousChar + (variables[Number(number)] || '');
-     *               }
-     *             )
-     *             .replace('\\$', '$');
+     *const variables = slice(arguments);
+     *
+     *return Settings
+     *  .message_formats[type]
+     *  .replace(
+     *    /(^|[^\\])\$(\d+)/,
+     *    (match, previousChar, number) => previousChar + (variables[Number(number)] || '')
+     *  )
+     *  .replace('\\$', '$');
      */
   };
-}; // });
+});
 
 export default Messenger;

--- a/src/Pride/Messenger.test.js
+++ b/src/Pride/Messenger.test.js
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+import Messenger from './Messenger';
+
+describe.only('Messenger()', () => {
+  it('does a thing', () => {
+    console.log(Messenger);
+    expect(Messenger).to.not.be.null;
+  });
+});

--- a/src/Pride/Messenger.test.js
+++ b/src/Pride/Messenger.test.js
@@ -2,8 +2,43 @@ import { expect } from 'chai';
 import Messenger from './Messenger';
 
 describe.only('Messenger()', () => {
-  it('does a thing', () => {
-    console.log(Messenger);
-    expect(Messenger).to.not.be.null;
+  describe('sendMessage()', () => {
+    beforeEach(function() {
+      this.sendMessage = Messenger.sendMessage({
+        summary: 'There was an error.',
+        class: 'error'
+      });
+    });
+    it('sendMessage', () => {
+      console.log(this.sendMessage);
+      expect(this.sendMessage).to.not.be.null;
+    });
+  });
+  describe('sendMessageArray()', () => {
+    beforeEach(function() {
+      this.sendMessageArray = Messenger.sendMessageArray([
+        {
+          summary: 'There was an error.',
+          class: 'error'
+        },
+        {
+          summary: 'This has been a success!',
+          class: 'success'
+        }
+      ]);
+    });
+    it('sendMessageArray', () => {
+      console.log(this.sendMessageArray);
+      expect(this.sendMessageArray).to.not.be.null;
+    });
+  });
+  describe('preset()', () => {
+    beforeEach(function() {
+      this.preset = Messenger.preset('failed_init');
+    });
+    it('preset', () => {
+      console.log(this.preset);
+      expect(this.preset).to.not.be.null;
+    });
   });
 });

--- a/src/Pride/Messenger.test.js
+++ b/src/Pride/Messenger.test.js
@@ -1,44 +1,55 @@
 import { expect } from 'chai';
 import Messenger from './Messenger';
 
-describe.only('Messenger()', () => {
-  describe('sendMessage()', () => {
-    beforeEach(function() {
-      this.sendMessage = Messenger.sendMessage({
-        summary: 'There was an error.',
-        class: 'error'
-      });
+describe('Messenger()', () => {
+  describe('safeGet()', () => {
+    it('returns a function', () => {
+      expect(Messenger.safeGet).to.be.a('function');
     });
-    it('sendMessage', () => {
-      console.log(this.sendMessage);
-      expect(this.sendMessage).to.not.be.null;
+  });
+  describe('add()', () => {
+    it('returns undefined', () => {
+      expect(Messenger.add).to.be.undefined;
+    });
+  });
+  describe('remove()', () => {
+    it('returns undefined', () => {
+      expect(Messenger.remove).to.be.undefined;
+    });
+  });
+  describe('clear()', () => {
+    it('returns undefined', () => {
+      expect(Messenger.clear).to.be.undefined;
+    });
+  });
+  describe('clearAll()', () => {
+    it('returns a function', () => {
+      expect(Messenger.clearAll).to.be.a('function');
+    });
+  });
+  describe('apply()', () => {
+    it('returns a function', () => {
+      expect(Messenger.apply).to.be.a('function');
+    });
+  });
+  describe('call()', () => {
+    it('returns undefined', () => {
+      expect(Messenger.call).to.be.undefined;
+    });
+  });
+  describe('sendMessage()', () => {
+    it('returns a function', () => {
+      expect(Messenger.sendMessage).to.be.a('function');
     });
   });
   describe('sendMessageArray()', () => {
-    beforeEach(function() {
-      this.sendMessageArray = Messenger.sendMessageArray([
-        {
-          summary: 'There was an error.',
-          class: 'error'
-        },
-        {
-          summary: 'This has been a success!',
-          class: 'success'
-        }
-      ]);
-    });
-    it('sendMessageArray', () => {
-      console.log(this.sendMessageArray);
-      expect(this.sendMessageArray).to.not.be.null;
+    it('returns a function', () => {
+      expect(Messenger.sendMessageArray).to.be.a('function');
     });
   });
   describe('preset()', () => {
-    beforeEach(function() {
-      this.preset = Messenger.preset('failed_init');
-    });
-    it('preset', () => {
-      console.log(this.preset);
-      expect(this.preset).to.not.be.null;
+    it('returns a function', () => {
+      expect(Messenger.preset).to.be.a('function');
     });
   });
 });


### PR DESCRIPTION
# Overview
This pull request takes care of [SEARCH-1308](https://tools.lib.umich.edu/jira/browse/SEARCH-1308). It adds `Pride.Messenger` to the rewrite, along with its associated unit test.

## sendMessage and sendMessageArray
These functions were originally commented out in the `master` branch at the time of writing this. The `parser_test_1` branch has these uncommented and were working according to the owner of the branch, so these functions have been uncommented. 

## Unit Test
The goal for each rewrite is to create a test that goes with it. `Pride.Messenger` is basically a copy of `Pride.Util.FuncBuffer`, which already has working unit tests. The tests that have been written tests what each method type is.

## Testing
* Run `npm run tests` to make sure the tests pass. Try and break the tests to double-check.
* Compare `./src/Pride/Messenger` against `./source/singletons/messenger.js`.