### PR TITLE
[SEARCH-1391] Pride.Core.DatastoreBrowse

### DIFF
--- a/src/Pride/Core.js
+++ b/src/Pride/Core.js
@@ -1,5 +1,6 @@
 import BrowseBase from './Core/BrowseBase';
 import Datastore from './Core/Datastore';
+import DatastoreBrowse from './Core/DatastoreBrowse';
 import DatastoreSearch from './Core/DatastoreSearch';
 import FacetSearch from './Core/FacetSearch';
 import GetThis from './Core/GetThis';
@@ -17,6 +18,7 @@ const Core = {
 
 Object.defineProperty(Core, 'BrowseBase', { value: BrowseBase });
 Object.defineProperty(Core, 'Datastore', { value: Datastore });
+Object.defineProperty(Core, 'DatastoreBrowse', { value: DatastoreBrowse });
 Object.defineProperty(Core, 'DatastoreSearch', { value: DatastoreSearch });
 Object.defineProperty(Core, 'FacetSearch', { value: FacetSearch });
 Object.defineProperty(Core, 'GetThis', { value: GetThis });

--- a/src/Pride/Core/Datastore.js
+++ b/src/Pride/Core/Datastore.js
@@ -2,6 +2,7 @@ import _ from 'underscore';
 import deepClone from '../Util/deepClone';
 import Query from './Query';
 import DatastoreSearch from './DatastoreSearch';
+import DatastoreBrowse from './DatastoreBrowse';
 import request from '../Util/request';
 
 const Datastore = function(datastoreInfo) {
@@ -34,6 +35,17 @@ const Datastore = function(datastoreInfo) {
 
   this.runQuery = function(requestArguments) {
     requestArguments.url = datastoreInfo.url;
+    request(requestArguments);
+
+    return this;
+  };
+
+  this.baseBrowse = function() {
+    return new DatastoreBrowse({ datastore: this });
+  };
+
+  this.runBrowse = function(requestArguments) {
+    requestArguments.url = `${datastoreInfo.url}/browse`;
     request(requestArguments);
 
     return this;

--- a/src/Pride/Core/Datastore.test.js
+++ b/src/Pride/Core/Datastore.test.js
@@ -45,6 +45,25 @@ describe('Datastore()', () => {
      * });
      */
   });
+  describe('baseBrowse()', () => {
+    it('is a function', () => {
+      expect(this.datastoreExample.baseBrowse).to.be.a('function');
+    });
+  });
+  describe('runBrowse()', () => {
+    it('is a function', () => {
+      expect(this.datastoreExample.runBrowse).to.be.a('function');
+    });
+    it('requires argument to have `url` property', () => {
+      expect(() => this.datastoreExample.runBrowse()).to.throw('Cannot set property \'url\' of undefined');
+    });
+    // Commented out to not run 'request'.
+    /*
+     * it('returns self', () => {
+     *   expect(this.datastoreExample.runBrowse({})).to.deep.equal(this.datastoreExample);
+     * });
+     */
+  });
   describe('get()', () => {
     it('is a function', () => {
       expect(this.datastoreExample.get).to.be.a('function');

--- a/src/Pride/Core/DatastoreBrowse.js
+++ b/src/Pride/Core/DatastoreBrowse.js
@@ -1,0 +1,98 @@
+import _ from 'underscore';
+import BrowseBase from './BrowseBase';
+import Record from './Record';
+import deepClone from '../Util/deepClone';
+import isDeepMatch from '../Util/isDeepMatch';
+import FacetSearch from './FacetSearch';
+
+const DatastoreBrowse = function(setup) {
+  const base = new BrowseBase(setup, this);
+
+  base.createItem = (itemData) => {
+    return new Record(itemData);
+  };
+
+  /**
+   * Facet Searches
+   */
+
+  let facetSearches = [];
+  let currentFacets = [];
+
+  this.getFacets = () => {
+    return facetSearches;
+  };
+
+  /**
+   * Data Getters
+   */
+
+  this.uid = base.datastore.get('uid');
+
+  this.getData = () => {
+    return {
+      uid: this.uid,
+      metadata: deepClone(base.datastore.get('metadata')),
+      sorts: deepClone(base.datastore.get('sorts')),
+      selected_sort: base.query.get('sort'),
+      facets: deepClone(base.query.get('facets')),
+      fields: deepClone(base.datastore.get('fields')),
+      field_tree: deepClone(base.query.get('field_tree')),
+      settings: deepClone(base.query.get('settings')),
+      page: base.query.get('page'),
+      count: base.query.get('count'),
+      total_available: base.query.get('total_available'),
+      total_pages: base.query.get('total_pages'),
+      page_limit: base.query.get('page_limit'),
+      specialists: deepClone(base.query.get('specialists'))
+    };
+  };
+
+  this.getResults = base.results;
+
+  /**
+   * Observerables
+   */
+
+  base.initialize_observables = () => {
+    this.runDataObservers.add(() => {
+      const facets = base.datastore.get('facets');
+
+      if (!isDeepMatch(currentFacets, facets)) {
+        _.each(facetSearches, (facetSearch) => {
+          facetSearch.clearAllObservers();
+        });
+
+        facetSearches = _.map(
+          facets,
+          (facetData) => {
+            return new FacetSearch({
+              data: _.omit(facetData, 'values'),
+              results: facetData.values
+            });
+          }
+        );
+
+        currentFacets = facets;
+
+        this.facetsObservers.notify();
+      }
+    });
+  };
+
+  this.getMute = base.getMute;
+
+  this.setMute = (state) => {
+    _.each(facetSearches, (facet) => {
+      facet.setMute(state);
+    });
+    base.setMute(state);
+
+    return this;
+  };
+
+  base.createObservable('facets', this.getFacets)
+    .initialize_observables();
+};
+
+export default DatastoreBrowse;

--- a/src/Pride/Core/DatastoreBrowse.test.js
+++ b/src/Pride/Core/DatastoreBrowse.test.js
@@ -2,7 +2,7 @@ import { JSDOM } from 'jsdom';
 import { expect } from 'chai';
 import DatastoreBrowse from './DatastoreBrowse';
 
-describe.only('DatastoreBrowse()', () => {
+describe('DatastoreBrowse()', () => {
   before(() => {
     const dom = new JSDOM();
     global.window = dom.window;

--- a/src/Pride/Core/DatastoreBrowse.test.js
+++ b/src/Pride/Core/DatastoreBrowse.test.js
@@ -1,0 +1,94 @@
+import { JSDOM } from 'jsdom';
+import { expect } from 'chai';
+import DatastoreBrowse from './DatastoreBrowse';
+
+describe.only('DatastoreBrowse()', () => {
+  before(() => {
+    const dom = new JSDOM();
+    global.window = dom.window;
+    this.setup = {
+      datastore: {
+        get: (arg) => this.setup.datastore[arg],
+        baseQuery: () => {},
+        runQuery: () => {},
+        uid: 'UID Value',
+        metadata: 'Metadata Value',
+        sorts: 'Sorts Value',
+        fields: 'Fields Value'
+      },
+      query: {
+        get: (arg) => this.setup.query[arg],
+        set: () => {},
+        to_section: {},
+        selected_sort: 'SelectedSort Value',
+        facets: 'Facets Value',
+        field_tree: 'Field Tree Value',
+        settings: 'Settings Value',
+        page: 'Page Value',
+        count: 'Count Value',
+        total_available: 'Total Available Value',
+        total_pages: 'Total Pages Value',
+        page_limit: 'Page Limit Value',
+        specialists: 'Specialists Value'
+      },
+      requestFunc: '',
+      starting_results: '',
+      cacheSize: 1
+    };
+    this.datastoreBrowseExample = new DatastoreBrowse(this.setup);
+  });
+  it('works', () => {
+    expect(DatastoreBrowse).to.not.be.null;
+  });
+  describe('getFacets()', () => {
+    it('returns an array', () => {
+      expect(this.datastoreBrowseExample.getFacets()).to.be.an('array');
+    });
+  });
+  describe('uid', () => {
+    it('returns setup.datastore.uid', () => {
+      expect(this.datastoreBrowseExample.uid).to.equal(this.setup.datastore.uid);
+    });
+  });
+  describe('getData()', () => {
+    it('returns an object', () => {
+      expect(this.datastoreBrowseExample.getData()).to.be.an('object');
+    });
+    it('returns the necessary datastore and query data', () => {
+      expect(this.datastoreBrowseExample.getData()).to.deep.equal({
+        uid: this.setup.datastore.uid,
+        metadata: this.setup.datastore.get('metadata'),
+        sorts: this.setup.datastore.get('sorts'),
+        selected_sort: this.setup.query.get('sort'),
+        facets: this.setup.query.get('facets'),
+        fields: this.setup.datastore.get('fields'),
+        field_tree: this.setup.query.get('field_tree'),
+        settings: this.setup.query.get('settings'),
+        page: this.setup.query.get('page'),
+        count: this.setup.query.get('count'),
+        total_available: this.setup.query.get('total_available'),
+        total_pages: this.setup.query.get('total_pages'),
+        page_limit: this.setup.query.get('page_limit'),
+        specialists: this.setup.query.get('specialists')
+      });
+    });
+  });
+  describe('getResults', () => {
+    it('is a function', () => {
+      expect(this.datastoreBrowseExample.getResults).to.be.a('function');
+    });
+  });
+  describe('getMute', () => {
+    it('returns a boolean', () => {
+      expect(this.datastoreBrowseExample.getMute()).to.be.a('boolean');
+    });
+    it('is false by default', () => {
+      expect(this.datastoreBrowseExample.getMute()).to.be.false;
+    });
+  });
+  describe('setMute()', () => {
+    it('returns self', () => {
+      expect(this.datastoreBrowseExample.setMute()).to.deep.equal(this.datastoreBrowseExample);
+    });
+  });
+});


### PR DESCRIPTION
# Overview
This pull request takes care of [SEARCH-1391](https://tools.lib.umich.edu/jira/browse/SEARCH-1391). It adds `Pride.Core.DatastoreBrowse` to the rewrite, along with its associated unit test.

## Testing
* Run `npm run tests` to make sure the tests pass. Try and break the tests to double-check.
* Compare `./src/Pride/Core/DatastoreBrowse.js` against `./source/constructors/datastore_browse.js`.