### PR TITLE
Adding tests to see if all sibling files are declared as properties.

### DIFF
--- a/spec/Pride/Core/index.spec.js
+++ b/spec/Pride/Core/index.spec.js
@@ -1,8 +1,16 @@
 const { expect } = require('chai');
-const Pride = require('../../../pride').Pride;
+const Core = require('../../../pride').Pride.Core;
+const { siblingFileIsProperty } = require('../index.spec');
 
 describe('Pride.Core', function () {
   it('works', function () {
-    expect(Pride.Core).to.not.be.null;
+    expect(Core).to.not.be.null;
+  });
+  it('is a non-empty object', function () {
+    expect(Core).to.be.an('object');
+    expect(Core).to.not.be.empty;
+  });
+  describe('sibling files are defined as properties', () => {
+    siblingFileIsProperty('Pride.Core', Core);
   });
 });

--- a/spec/Pride/FieldTree/index.spec.js
+++ b/spec/Pride/FieldTree/index.spec.js
@@ -1,8 +1,16 @@
 const { expect } = require('chai');
-const Pride = require('../../../pride').Pride;
+const FieldTree = require('../../../pride').Pride.FieldTree;
+const { siblingFileIsProperty } = require('../index.spec');
 
 describe('Pride.FieldTree', function () {
   it('works', function () {
-    expect(Pride.FieldTree).to.not.be.null;
+    expect(FieldTree).to.not.be.null;
+  });
+  it('is a non-empty object', function () {
+    expect(FieldTree).to.be.an('object');
+    expect(FieldTree).to.not.be.empty;
+  });
+  describe('sibling files are defined as properties', () => {
+    siblingFileIsProperty('Pride.FieldTree', FieldTree);
   });
 });

--- a/spec/Pride/Util/Paginater/index.spec.js
+++ b/spec/Pride/Util/Paginater/index.spec.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const _ = require('underscore');
 const Paginater = require('../../../../pride').Pride.Util.Paginater;
+const { siblingFileIsProperty } = require('../../index.spec');
 
 function paginatorBasicExpectations (key1, key2, valid) {
   beforeEach(function () {
@@ -95,5 +96,8 @@ describe('Pride.Util.Paginater', function () {
         }
       ).to.throw();
     });
+  });
+  describe('sibling files are defined as properties', () => {
+    siblingFileIsProperty('Pride.Util.Paginater', Paginater);
   });
 });

--- a/spec/Pride/Util/index.spec.js
+++ b/spec/Pride/Util/index.spec.js
@@ -1,8 +1,16 @@
 const { expect } = require('chai');
-const Pride = require('../../../pride').Pride;
+const Util = require('../../../pride').Pride.Util;
+const { siblingFileIsProperty } = require('../index.spec');
 
 describe('Pride.Util', function () {
   it('works', function () {
-    expect(Pride.Util).to.not.be.null;
+    expect(Util).to.not.be.null;
+  });
+  it('is a non-empty object', function () {
+    expect(Util).to.be.an('object');
+    expect(Util).to.not.be.empty;
+  });
+  describe('sibling files are defined as properties', () => {
+    siblingFileIsProperty('Pride.Util', Util);
   });
 });

--- a/spec/Pride/index.spec.js
+++ b/spec/Pride/index.spec.js
@@ -1,8 +1,35 @@
+const fs = require('fs');
 const { expect } = require('chai');
 const Pride = require('../../pride').Pride;
+
+const siblingFileIsProperty = (callProperty, property) => {
+  // Get list of nested properties
+  const propertyPath = callProperty.split('.');
+  // Check associated `src` directory
+  fs.readdirSync(`src/${propertyPath.join('/')}`).forEach((listing) => {
+    // Check if current listing is a non-index JavaScript file
+    if (listing.endsWith('.js') && !listing.endsWith('index.js')) {
+      // Remove the file extension
+      const propertyName = listing.replace('.js', '');
+      // Return test to see if the file exists as a property
+      it(`'${propertyName}' is a property of '${propertyPath.slice(-1)}'`, () => {
+        expect(Object.keys(property).includes(propertyName)).to.be.true;
+      });
+    }
+  });
+};
 
 describe('Pride', function () {
   it('works', function () {
     expect(Pride).to.not.be.null;
   });
+  it('is a non-empty object', function () {
+    expect(Pride).to.be.an('object');
+    expect(Pride).to.not.be.empty;
+  });
+  describe('sibling files are defined as properties', () => {
+    siblingFileIsProperty('Pride', Pride);
+  });
 });
+
+exports.siblingFileIsProperty = siblingFileIsProperty;


### PR DESCRIPTION
# Overview
The `siblingFileIsProperty` function sees if there are any JavaScript files that are not declared as a property in the given object. For example, `src/Pride/Util/safeApply.js` is the existing property `Pride.Util.safeApply`, but if you created the file `src/Pride/Util/test.js`, the property `Pride.Util.test` is undefined and would therefor break the tests. All JavaScript files must be assigned appropriately.

## Testing
1. Build the repository (`npm run build`).
2. Run the tests to make sure they pass (`npm run test`).
   * Break the new/updated unit tests to make sure they're working properly.