### PR TITLE
Pride.Util.escape

### DIFF
--- a/spec/Pride/Util/deepClone.spec.js
+++ b/spec/Pride/Util/deepClone.spec.js
@@ -71,7 +71,7 @@ describe('Pride.Util.deepClone()', function () {
 
   it('clones strings', function () {
     const string = 'string';
-    const cloned = Pride.Util.deepClone(string);
+    const cloned = deepClone(string);
 
     expect(cloned).to.equal(string);
   });

--- a/spec/Pride/Util/escape.spec.js
+++ b/spec/Pride/Util/escape.spec.js
@@ -11,19 +11,20 @@ const symbols = [
   {
     symbol: '<',
     html: '&lt;'
+  },
+  {
+    symbol: '>',
+    html: '&gt;'
   }
 ];
 
-function testEscaping (character) {
-  it(`encodes ${character.symbol} properly`, function () {
-    const tempElement = document.createElement('div');
-    tempElement.appendChild(document.createTextNode(character.symbol));
-    expect(tempElement.innerHTML).to.equal(character.html);
-  });
-};
-
 describe('Pride.Util.escape()', function () {
   symbols.forEach((symbol) => {
-    testEscaping(symbol);
+    it(`encodes ${symbol.symbol} properly`, function () {
+      // Copy code from ./src/Pride/Util/escape.js to define `document`
+      const tempElement = document.createElement('div');
+      tempElement.appendChild(document.createTextNode(symbol.symbol));
+      expect(tempElement.innerHTML).to.equal(symbol.html);
+    });
   });
 });


### PR DESCRIPTION
# Overview
`Pride.Util.escape` tests has been updated with an extra symbol to test, and moving the function into `forEach`.

## Anything else?
`Pride.Util.deepClone` spec has been updated to fix undefined error.

## Testing
1. Build the repository (`npm run build`).
2. Run the tests to make sure they pass (`npm run test`).
   * Break the new/updated unit tests to make sure they're working properly.
3. Navigate to your local [Search repository](https://github.com/mlibrary/search) and apply the newly generated files:
   1. Open `./package.json` and add `#Pride-Util-escape` at the end of the `pride` dependency URL:
      ```bash
      "pride": "git+https://github.com/mlibrary/pride.git#Pride-Util-escape"
      ``` 
   2. Do a clean install of Search:
      ```bash
      rm -rf node_modules && rm package-lock.json && npm install
      ``` 
   3. Start Search (`npm start`) and look around [the site](http://localhost:3000/everything). Check to see if there are any console errors, and everything still works as expected.
- _How to use the feature_.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
