### PR TITLE
Pride.FieldTree.Literal

### DIFF
--- a/spec/Pride/FieldTree/Literal.spec.js
+++ b/spec/Pride/FieldTree/Literal.spec.js
@@ -1,8 +1,42 @@
 const { expect } = require('chai');
-const Pride = require('../../../pride').Pride;
+const Literal = require('../../../pride').Pride.FieldTree.Literal;
 
 describe('Pride.FieldTree.Literal', function () {
+  const testLiteral = 'testLiteral';
+  let createLiteral;
+
+  beforeEach(function () {
+    createLiteral = function () {
+      return new Literal(testLiteral, ...arguments);
+    };
+  });
+
   it('works', function () {
-    expect(Pride.FieldTree.Literal).to.not.be.null;
+    expect(Literal).to.not.be.null;
+  });
+
+  describe('type', function () {
+    it('defines the type via a string', function () {
+      expect(createLiteral().type).to.be.a('string');
+      expect(createLiteral().type).deep.equal('literal');
+    });
+  });
+
+  describe('childTypes', function () {
+    it('does not have any childTypes', function () {
+      expect(createLiteral().childTypes).to.be.an('array').and.to.be.empty;
+    });
+  });
+
+  describe('extension', function () {
+    it('serializes correctly with no children', function () {
+      const field = createLiteral();
+      expect(field.serialize()).to.equal(testLiteral);
+    });
+
+    it('does not return children', function () {
+      const field = createLiteral(new Literal('childLiteral'));
+      expect(field.serialize()).to.equal(testLiteral);
+    });
   });
 });


### PR DESCRIPTION
# Overview
`Pride.FieldTree.Literal` has tests written for `type`, `childTypes`, and `extension`. No changes were made for simplifying the class.

## Testing
1. Build the repository (`npm run build`).
2. Run the tests to make sure they pass (`npm run test`).
   * Break the new/updated unit tests to make sure they're working properly.
3. Navigate to your local [Search repository](https://github.com/mlibrary/search) and apply the newly generated files:
   1. Open `./package.json` and add `#Pride-FieldTree-Literal` at the end of the `pride` dependency URL:
      ```bash
      "pride": "git+https://github.com/mlibrary/pride.git#Pride-FieldTree-Literal"
      ``` 
   2. Do a clean install of Search:
      ```bash
      rm -rf node_modules && rm package-lock.json && npm install
      ``` 
   3. Start Search (`npm start`) and look around [the site](http://localhost:3000/everything). Check to see if there are any console errors, and everything still works as expected.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
