### PR TITLE
Pride.FieldTree.Raw

### DIFF
--- a/spec/Pride/FieldTree/Special.spec.js
+++ b/spec/Pride/FieldTree/Special.spec.js
@@ -1,8 +1,42 @@
 const { expect } = require('chai');
-const Pride = require('../../../pride').Pride;
+const Special = require('../../../pride').Pride.FieldTree.Special;
 
 describe('Pride.FieldTree.Special', function () {
+  const testSpecial = 'testSpecial';
+  let createSpecial;
+
+  beforeEach(function () {
+    createSpecial = function () {
+      return new Special(testSpecial, ...arguments);
+    };
+  });
+
   it('works', function () {
-    expect(Pride.FieldTree.Special).to.not.be.null;
+    expect(Special).to.not.be.null;
+  });
+
+  describe('type', function () {
+    it('defines the type via a string', function () {
+      expect(createSpecial().type).to.be.a('string');
+      expect(createSpecial().type).deep.equal('special');
+    });
+  });
+
+  describe('childTypes', function () {
+    it('does not have any childTypes', function () {
+      expect(createSpecial().childTypes).to.be.an('array').and.to.be.empty;
+    });
+  });
+
+  describe('extension', function () {
+    it('serializes correctly with no children', function () {
+      const field = createSpecial();
+      expect(field.serialize()).to.equal(testSpecial);
+    });
+
+    it('does not return children', function () {
+      const field = createSpecial(new Special('childSpecial'));
+      expect(field.serialize()).to.equal(testSpecial);
+    });
   });
 });


### PR DESCRIPTION
# Overview
`Pride.FieldTree.Raw` has tests written for `type`, `childTypes`, and `extension`. No changes were made for simplifying the class.

## Testing
1. Build the repository (`npm run build`).
2. Run the tests to make sure they pass (`npm run test`).
   * Break the new/updated unit tests to make sure they're working properly.
3. Navigate to your local [Search repository](https://github.com/mlibrary/search) and apply the newly generated files:
   1. Open `./package.json` and add `#Pride-FieldTree-Raw` at the end of the `pride` dependency URL:
      ```bash
      "pride": "git+https://github.com/mlibrary/pride.git#Pride-FieldTree-Raw"
      ``` 
   2. Do a clean install of Search:
      ```bash
      rm -rf node_modules && rm package-lock.json && npm install
      ``` 
   3. Start Search (`npm start`) and look around [the site](http://localhost:3000/everything). Check to see if there are any console errors, and everything still works as expected.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
