### PR TITLE
Adding `pre-commit` hook, `init.sh` script, and updating `README.md`.

### DIFF
--- a/.github/pre-commit
+++ b/.github/pre-commit
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Get the list of staged .js files
+STAGED_JS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '.*\.js$')
+
+# Exit if no .js files are staged
+if [ "$STAGED_JS_FILES" = "" ]; then
+  exit 0
+fi
+
+# Run ESLint on the staged .js files
+echo "Running ESLint..."
+npx eslint $STAGED_JS_FILES
+
+# Capture ESLint exit code
+ESLINT_RESULT=$?
+
+# Exit with ESLint's result code
+if [ $ESLINT_RESULT -ne 0 ]; then
+  echo "ESLint failed. Commit aborted."
+  exit 1
+fi
+
+# Get the list of staged .spec.js files
+STAGED_SPEC_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '.*\.spec\.js$')
+
+# Run tests on staged .spec.js files
+if [ "$STAGED_SPEC_FILES" != "" ]; then
+  # Run Mocha tests
+  echo "Running Mocha tests..."
+  npx mocha $STAGED_SPEC_FILES
+  MOCHA_RESULT=$?
+
+  if [ $MOCHA_RESULT -ne 0 ]; then
+    echo "Mocha tests failed. Commit aborted."
+    exit 1
+  fi
+fi
+
+echo "All checks passed. Proceeding with commit."
+exit 0

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # Pride
 Pride is a JavaScript library that handles all communication between the [University of Michigan Library Search](https://search.lib.umich.edu/everything)'s [front-end application](https://github.com/mlibrary/search) and the [backend](https://github.com/mlibrary/spectrum).
 
-## Setup
+## To Start
+
+Run the `init.sh` script.
 
 ```bash
-npm install
-```
-
-## Build
-
-```bash
-npm run build
+./init.sh
 ```
 
 All files that are included in the build are found under `src/`. The directory is organized by object property. Examples:

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Must run from the project root directory
+echo "🪝 Copying .github/pre-commit to .git/hooks/"
+cp .github/pre-commit .git/hooks/pre-commit
+
+echo "📥 Installing Node modules"
+npm install
+
+echo "🛠 Building JavaScript"
+npm run build


### PR DESCRIPTION
In an effort to boost QA, a script has been added that creates a `pre-commit` hook to make sure the staged files are:
1) Passing via `eslint`
2) If any of the files are tests, the tests pass.