### PR TITLE
Use git SHA for ALL GitHub actions by Wednesday, April 15

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install latest LTS version of Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: lts/*
           check-latest: true


### PR DESCRIPTION
* _Action required:_ we will configure GitHub to prevent any actions from running if the SHA isn't use on Wednesday, April 15
* All actions used in your GitHub workflows should be updated to use the full SHA. We recommend also adding a human readable version tag in a comment. Dependabot will update both the SHA and the comment as long as the full version tag is used, and it matches the SHA.
* See example: [sample workflow yaml](https://github.com/mlibrary/gha-sandbox/blob/main/.github/workflows/demo.yaml) | [dependabot PR updating this file](https://github.com/mlibrary/gha-sandbox/pull/4/changes)
  * Note: comment tags must match release tag exactly (e.g. v6.3.0, not v6) in order for dependabot to maintain them for you